### PR TITLE
fix(frapps): inability to enter username fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2023-04-11
+
+### Fixed
+
+- Inability to enter user name / password when prompted fixed.
+
 ## [0.1.0] - 2023-01-12
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "frapps"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "env_logger",
  "frappslib",
@@ -498,7 +498,7 @@ dependencies = [
 
 [[package]]
 name = "frappslib"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "chrono",
  "futures",

--- a/apps/frapps/Cargo.toml
+++ b/apps/frapps/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frapps"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/libs/frapps-npm/package.json
+++ b/libs/frapps-npm/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "frapps",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/ziacik/frapps"

--- a/libs/frapps-npm/src/run.ts
+++ b/libs/frapps-npm/src/run.ts
@@ -17,13 +17,16 @@ async function run() {
 
 	console.log('Running', binaryPath);
 
-	const child = spawn(binaryPath, process.argv.slice(2));
+	const child = spawn(binaryPath, process.argv.slice(2), {
+		shell: true,
+		stdio: 'inherit',
+	});
 
-	child.stdout.on('data', (data: unknown) => {
+	child.stdout?.on('data', (data: unknown) => {
 		console.log(`${data}`);
 	});
 
-	child.stderr.on('data', (data: unknown) => {
+	child.stderr?.on('data', (data: unknown) => {
 		console.error(`${data}`);
 	});
 

--- a/libs/frappslib/Cargo.toml
+++ b/libs/frappslib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frappslib"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
This was because when run via node spawn, the rust frapps bin somehow wasn't able to receive the Enter key.